### PR TITLE
Refactor MySqlConnectorWrapper and related interfaces/classes

### DIFF
--- a/GateKeeper.Server/Database/MySqlConnectorWrapper.cs
+++ b/GateKeeper.Server/Database/MySqlConnectorWrapper.cs
@@ -9,7 +9,7 @@ namespace GateKeeper.Server.Database
 
 
     // Concrete class implementing the interface
-    public class MySqlConnectorWrapper : IMySqlConnectorWrapper, IAsyncDisposable
+    public class MySqlConnectorWrapper : IMySqlConnectorWrapper
     {
         private readonly MySqlConnection _connection;
 
@@ -80,57 +80,4 @@ namespace GateKeeper.Server.Database
         }
 
     }
-
-    public class MySqlDataReaderWrapper : IMySqlDataReaderWrapper, IAsyncDisposable
-    {
-        private readonly MySqlDataReader _reader;
-
-        public MySqlDataReaderWrapper(MySqlDataReader reader)
-        {
-            _reader = reader;
-        }
-
-        public async Task<bool> ReadAsync(CancellationToken cancellationToken = default)
-        {
-            return await _reader.ReadAsync(cancellationToken);
-        }
-
-        public object this[string name] => _reader[name];
-
-        public int GetInt32(string name)
-        {
-            return _reader.GetInt32(_reader.GetOrdinal(name));
-        }
-
-        public string GetString(string name)
-        {
-            return _reader.GetString(_reader.GetOrdinal(name));
-        }
-
-        public DateTime GetDateTime(string name)
-        {
-            return _reader.GetDateTime(_reader.GetOrdinal(name));
-        }
-
-        public bool IsDBNull(int ordinal)
-        {
-            return _reader.IsDBNull(ordinal);
-        }
-
-        public int GetOrdinal(string name)
-        {
-            return _reader.GetOrdinal(name);
-        }
-
-        public async Task<bool> NextResultAsync(CancellationToken cancellationToken = default)
-        {
-            return await _reader.NextResultAsync(cancellationToken);
-        }
-
-        public ValueTask DisposeAsync()
-        {
-            return _reader.DisposeAsync();
-        }
-    }
-
 }

--- a/GateKeeper.Server/Database/MySqlDataReaderWrapper.cs
+++ b/GateKeeper.Server/Database/MySqlDataReaderWrapper.cs
@@ -1,0 +1,60 @@
+using GateKeeper.Server.Interface;
+using MySqlConnector;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace GateKeeper.Server.Database
+{
+    public class MySqlDataReaderWrapper : IMySqlDataReaderWrapper, IAsyncDisposable
+    {
+        private readonly MySqlDataReader _reader;
+
+        public MySqlDataReaderWrapper(MySqlDataReader reader)
+        {
+            _reader = reader;
+        }
+
+        public async Task<bool> ReadAsync(CancellationToken cancellationToken = default)
+        {
+            return await _reader.ReadAsync(cancellationToken);
+        }
+
+        public object this[string name] => _reader[name];
+
+        public int GetInt32(string name)
+        {
+            return _reader.GetInt32(name);
+        }
+
+        public string GetString(string name)
+        {
+            return _reader.GetString(name);
+        }
+
+        public DateTime GetDateTime(string name)
+        {
+            return _reader.GetDateTime(name);
+        }
+
+        public bool IsDBNull(int ordinal)
+        {
+            return _reader.IsDBNull(ordinal);
+        }
+
+        public int GetOrdinal(string name)
+        {
+            return _reader.GetOrdinal(name);
+        }
+
+        public async Task<bool> NextResultAsync(CancellationToken cancellationToken = default)
+        {
+            return await _reader.NextResultAsync(cancellationToken);
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            return _reader.DisposeAsync();
+        }
+    }
+}

--- a/GateKeeper.Server/Interface/IMySqlConnectorWrapper.cs
+++ b/GateKeeper.Server/Interface/IMySqlConnectorWrapper.cs
@@ -13,16 +13,4 @@ namespace GateKeeper.Server.Interface
         void CloseConnection();
         Task<Dictionary<string, object>> ExecuteNonQueryWithOutputAsync(string commandText, CommandType commandType, params MySqlParameter[] parameters);
     }
-
-    public interface IMySqlDataReaderWrapper : IAsyncDisposable
-    {
-        Task<bool> ReadAsync(CancellationToken cancellationToken = default);
-        object this[string name] { get; }
-        int GetInt32(string name);
-        string GetString(string name);
-        DateTime GetDateTime(string name);
-        bool IsDBNull(int ordinal);
-        int GetOrdinal(string name);
-        Task<bool> NextResultAsync(CancellationToken cancellationToken = default);
-    }
 }

--- a/GateKeeper.Server/Interface/IMySqlDataReaderWrapper.cs
+++ b/GateKeeper.Server/Interface/IMySqlDataReaderWrapper.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace GateKeeper.Server.Interface
+{
+    public interface IMySqlDataReaderWrapper : IAsyncDisposable
+    {
+        Task<bool> ReadAsync(CancellationToken cancellationToken = default);
+        object this[string name] { get; }
+        int GetInt32(string name);
+        string GetString(string name);
+        DateTime GetDateTime(string name);
+        bool IsDBNull(int ordinal);
+        int GetOrdinal(string name);
+        Task<bool> NextResultAsync(CancellationToken cancellationToken = default);
+    }
+}


### PR DESCRIPTION
This commit improves the organization and clarity of the MySql database connector wrapper:

- Separated `IMySqlConnectorWrapper` and `IMySqlDataReaderWrapper` interfaces into their own files:
    - `IMySqlConnectorWrapper.cs`
    - `IMySqlDataReaderWrapper.cs`
- Separated `MySqlConnectorWrapper` and `MySqlDataReaderWrapper` classes into their own files:
    - `MySqlConnectorWrapper.cs`
    - `MySqlDataReaderWrapper.cs`
- Removed redundant `IAsyncDisposable` from `MySqlConnectorWrapper` class declaration, as it's already inherited from `IMySqlConnectorWrapper`.
- Simplified data retrieval methods in `MySqlDataReaderWrapper` (`GetInt32`, `GetString`, `GetDateTime`) to use direct `MySqlDataReader` overloads taking a string name, instead of calling `GetOrdinal` separately.

These changes enhance maintainability and adhere better to common C# code organization conventions.