### PR TITLE
feat: Implement centralized error handling middleware

### DIFF
--- a/GateKeeper.Server.Test/Middleware/GlobalExceptionHandlerMiddlewareTests.cs
+++ b/GateKeeper.Server.Test/Middleware/GlobalExceptionHandlerMiddlewareTests.cs
@@ -1,0 +1,308 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Hosting;
+using System;
+using System.IO;
+using System.Text.Json;
+using System.Threading.Tasks;
+using GateKeeper.Server.Middleware;
+using GateKeeper.Server.Models.Common;
+using GateKeeper.Server.Exceptions;
+using System.Diagnostics;
+
+namespace GateKeeper.Server.Test.Middleware
+{
+    [TestClass]
+    public class GlobalExceptionHandlerMiddlewareTests
+    {
+        private Mock<ILogger<GlobalExceptionHandlerMiddleware>> _mockLogger;
+        private Mock<IHostEnvironment> _mockHostEnvironment;
+        private DefaultHttpContext _httpContext;
+
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            _mockLogger = new Mock<ILogger<GlobalExceptionHandlerMiddleware>>();
+            _mockHostEnvironment = new Mock<IHostEnvironment>();
+            _httpContext = new DefaultHttpContext();
+            _httpContext.Response.Body = new MemoryStream(); // Important for capturing response
+        }
+
+        private async Task<ErrorResponse?> GetErrorResponseAsync(HttpResponse response)
+        {
+            response.Body.Seek(0, SeekOrigin.Begin);
+            var reader = new StreamReader(response.Body);
+            var responseBody = await reader.ReadToEndAsync();
+            if (string.IsNullOrEmpty(responseBody))
+            {
+                return null;
+            }
+            try
+            {
+                 return JsonSerializer.Deserialize<ErrorResponse>(responseBody, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+            }
+            catch (JsonException ex)
+            {
+                Console.WriteLine($"Failed to deserialize ErrorResponse: {ex.Message}. Response body: {responseBody}");
+                return null;
+            }
+        }
+
+        [TestMethod]
+        public async Task InvokeAsync_NoExceptionOccurs_CallsNextAndReturnsOk()
+        {
+            // Arrange
+            var mockRequestDelegate = new Mock<RequestDelegate>();
+            mockRequestDelegate.Setup(next => next(It.IsAny<HttpContext>())).Returns(Task.CompletedTask);
+
+            var middleware = new GlobalExceptionHandlerMiddleware(
+                next: mockRequestDelegate.Object,
+                logger: _mockLogger.Object,
+                env: _mockHostEnvironment.Object
+            );
+
+            var initialStatusCode = _httpContext.Response.StatusCode; // Usually 200 by default
+
+            // Act
+            await middleware.InvokeAsync(_httpContext);
+
+            // Assert
+            mockRequestDelegate.Verify(next => next(It.IsAny<HttpContext>()), Times.Once);
+            Assert.AreEqual(initialStatusCode, _httpContext.Response.StatusCode); // Status code should not be changed
+
+            // Verify no error logging occurred
+            _mockLogger.Verify(
+                x => x.Log(
+                    It.Is<LogLevel>(l => l == LogLevel.Error || l == LogLevel.Warning), // Check for Error or Warning
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((v, t) => true),
+                    It.IsAny<Exception>(),
+                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+                Times.Never);
+        }
+
+        [TestMethod]
+        public async Task InvokeAsync_GenericExceptionInDevelopment_Returns500WithDetails()
+        {
+            // Arrange
+            _mockHostEnvironment.Setup(e => e.EnvironmentName).Returns(Environments.Development);
+            var exceptionMessage = "Test generic exception in Development";
+            RequestDelegate nextDelegate = (ctx) => throw new Exception(exceptionMessage);
+
+            var middleware = new GlobalExceptionHandlerMiddleware(
+                next: nextDelegate,
+                logger: _mockLogger.Object,
+                env: _mockHostEnvironment.Object
+            );
+
+            var activity = new Activity("TestActivity").Start(); // To ensure Activity.Current.Id is not null
+            _httpContext.TraceIdentifier = "TestTraceId";
+
+
+            // Act
+            await middleware.InvokeAsync(_httpContext);
+
+            // Assert
+            Assert.AreEqual(StatusCodes.Status500InternalServerError, _httpContext.Response.StatusCode);
+            Assert.AreEqual("application/json", _httpContext.Response.ContentType);
+
+            var errorResponse = await GetErrorResponseAsync(_httpContext.Response);
+            Assert.IsNotNull(errorResponse);
+            Assert.AreEqual(StatusCodes.Status500InternalServerError, errorResponse.StatusCode);
+            Assert.AreEqual("An unexpected internal server error occurred. Please try again later.", errorResponse.Message);
+            Assert.IsNotNull(errorResponse.Details);
+            Assert.IsTrue(errorResponse.Details.Contains(exceptionMessage));
+            Assert.IsNotNull(errorResponse.TraceId);
+            Assert.IsTrue(errorResponse.TraceId.Contains(activity.Id!) || errorResponse.TraceId == "TestTraceId");
+
+
+            _mockLogger.Verify(
+               x => x.Log(
+                   LogLevel.Error,
+                   It.IsAny<EventId>(),
+                   It.Is<It.IsAnyType>((v, t) => v.ToString().Contains("An unhandled exception has occurred.")),
+                   It.IsAny<Exception>(),
+                   It.IsAny<Func<It.IsAnyType, Exception, string>>()),
+               Times.Once);
+
+            activity.Stop();
+        }
+
+        [TestMethod]
+        public async Task InvokeAsync_GenericExceptionInProduction_Returns500WithoutDetails()
+        {
+            // Arrange
+            _mockHostEnvironment.Setup(e => e.EnvironmentName).Returns(Environments.Production);
+            var exceptionMessage = "Test generic exception in Production";
+            RequestDelegate nextDelegate = (ctx) => throw new Exception(exceptionMessage);
+
+            var middleware = new GlobalExceptionHandlerMiddleware(
+                next: nextDelegate,
+                logger: _mockLogger.Object,
+                env: _mockHostEnvironment.Object
+            );
+
+            var activity = new Activity("TestActivity").Start();
+            _httpContext.TraceIdentifier = "TestTraceId";
+
+            // Act
+            await middleware.InvokeAsync(_httpContext);
+
+            // Assert
+            Assert.AreEqual(StatusCodes.Status500InternalServerError, _httpContext.Response.StatusCode);
+            Assert.AreEqual("application/json", _httpContext.Response.ContentType);
+
+            var errorResponse = await GetErrorResponseAsync(_httpContext.Response);
+            Assert.IsNotNull(errorResponse);
+            Assert.AreEqual(StatusCodes.Status500InternalServerError, errorResponse.StatusCode);
+            Assert.AreEqual("An unexpected internal server error occurred. Please try again later.", errorResponse.Message);
+            Assert.IsNull(errorResponse.Details, "Details should be null in Production environment.");
+            Assert.IsNotNull(errorResponse.TraceId);
+            Assert.IsTrue(errorResponse.TraceId.Contains(activity.Id!) || errorResponse.TraceId == "TestTraceId");
+
+            _mockLogger.Verify(
+               x => x.Log(
+                   LogLevel.Error,
+                   It.IsAny<EventId>(),
+                   It.Is<It.IsAnyType>((v, t) => v.ToString().Contains("An unhandled exception has occurred.")),
+                   It.IsAny<Exception>(),
+                   It.IsAny<Func<It.IsAnyType, Exception, string>>()),
+               Times.Once);
+            activity.Stop();
+        }
+
+        [TestMethod]
+        public async Task InvokeAsync_ValidationExceptionOccurs_Returns400WithExceptionMessage()
+        {
+            // Arrange
+            _mockHostEnvironment.Setup(e => e.EnvironmentName).Returns(Environments.Development); // Env shouldn't matter for details here
+            var exceptionMessage = "Test validation exception";
+            RequestDelegate nextDelegate = (ctx) => throw new ValidationException(exceptionMessage);
+
+            var middleware = new GlobalExceptionHandlerMiddleware(
+                next: nextDelegate,
+                logger: _mockLogger.Object,
+                env: _mockHostEnvironment.Object
+            );
+            
+            var activity = new Activity("TestActivity").Start();
+            _httpContext.TraceIdentifier = "TestTraceId";
+
+            // Act
+            await middleware.InvokeAsync(_httpContext);
+
+            // Assert
+            Assert.AreEqual(StatusCodes.Status400BadRequest, _httpContext.Response.StatusCode);
+            Assert.AreEqual("application/json", _httpContext.Response.ContentType);
+
+            var errorResponse = await GetErrorResponseAsync(_httpContext.Response);
+            Assert.IsNotNull(errorResponse);
+            Assert.AreEqual(StatusCodes.Status400BadRequest, errorResponse.StatusCode);
+            Assert.AreEqual(exceptionMessage, errorResponse.Message); // Custom message
+            Assert.IsNotNull(errorResponse.Details, "Details should be present in Development for custom exceptions too if desired.");
+            Assert.IsTrue(errorResponse.Details.Contains(exceptionMessage));
+            Assert.IsNotNull(errorResponse.TraceId);
+            Assert.IsTrue(errorResponse.TraceId.Contains(activity.Id!) || errorResponse.TraceId == "TestTraceId");
+
+             _mockLogger.Verify(
+                x => x.Log(
+                    LogLevel.Warning, // Should be LogWarning for ValidationException
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((v, t) => v.ToString().Contains("Validation error.")),
+                    It.IsAny<ValidationException>(), // Specific exception type
+                    It.IsAny<Func<It.IsAnyType, Exception, string>>()),
+                Times.Once);
+            activity.Stop();
+        }
+
+        [TestMethod]
+        public async Task InvokeAsync_ResourceNotFoundExceptionOccurs_Returns404WithExceptionMessage()
+        {
+            // Arrange
+            _mockHostEnvironment.Setup(e => e.EnvironmentName).Returns(Environments.Development);
+            var exceptionMessage = "Test resource not found exception";
+            RequestDelegate nextDelegate = (ctx) => throw new ResourceNotFoundException(exceptionMessage);
+
+            var middleware = new GlobalExceptionHandlerMiddleware(
+                next: nextDelegate,
+                logger: _mockLogger.Object,
+                env: _mockHostEnvironment.Object
+            );
+
+            var activity = new Activity("TestActivity").Start();
+            _httpContext.TraceIdentifier = "TestTraceId";
+
+            // Act
+            await middleware.InvokeAsync(_httpContext);
+
+            // Assert
+            Assert.AreEqual(StatusCodes.Status404NotFound, _httpContext.Response.StatusCode);
+            Assert.AreEqual("application/json", _httpContext.Response.ContentType);
+
+            var errorResponse = await GetErrorResponseAsync(_httpContext.Response);
+            Assert.IsNotNull(errorResponse);
+            Assert.AreEqual(StatusCodes.Status404NotFound, errorResponse.StatusCode);
+            Assert.AreEqual(exceptionMessage, errorResponse.Message);
+            Assert.IsNotNull(errorResponse.Details);
+            Assert.IsTrue(errorResponse.Details.Contains(exceptionMessage));
+            Assert.IsNotNull(errorResponse.TraceId);
+            Assert.IsTrue(errorResponse.TraceId.Contains(activity.Id!) || errorResponse.TraceId == "TestTraceId");
+
+            _mockLogger.Verify(
+               x => x.Log(
+                   LogLevel.Warning, 
+                   It.IsAny<EventId>(),
+                   It.Is<It.IsAnyType>((v, t) => v.ToString().Contains("Resource not found.")),
+                   It.IsAny<ResourceNotFoundException>(), 
+                   It.IsAny<Func<It.IsAnyType, Exception, string>>()),
+               Times.Once);
+            activity.Stop();
+        }
+
+        [TestMethod]
+        public async Task InvokeAsync_BusinessRuleExceptionOccurs_Returns400WithExceptionMessage()
+        {
+            // Arrange
+            _mockHostEnvironment.Setup(e => e.EnvironmentName).Returns(Environments.Development);
+            var exceptionMessage = "Test business rule exception";
+            RequestDelegate nextDelegate = (ctx) => throw new BusinessRuleException(exceptionMessage);
+
+            var middleware = new GlobalExceptionHandlerMiddleware(
+                next: nextDelegate,
+                logger: _mockLogger.Object,
+                env: _mockHostEnvironment.Object
+            );
+
+            var activity = new Activity("TestActivity").Start();
+            _httpContext.TraceIdentifier = "TestTraceId";
+
+            // Act
+            await middleware.InvokeAsync(_httpContext);
+
+            // Assert
+            Assert.AreEqual(StatusCodes.Status400BadRequest, _httpContext.Response.StatusCode);
+            Assert.AreEqual("application/json", _httpContext.Response.ContentType);
+
+            var errorResponse = await GetErrorResponseAsync(_httpContext.Response);
+            Assert.IsNotNull(errorResponse);
+            Assert.AreEqual(StatusCodes.Status400BadRequest, errorResponse.StatusCode);
+            Assert.AreEqual(exceptionMessage, errorResponse.Message);
+            Assert.IsNotNull(errorResponse.Details);
+            Assert.IsTrue(errorResponse.Details.Contains(exceptionMessage));
+            Assert.IsNotNull(errorResponse.TraceId);
+            Assert.IsTrue(errorResponse.TraceId.Contains(activity.Id!) || errorResponse.TraceId == "TestTraceId");
+
+            _mockLogger.Verify(
+               x => x.Log(
+                   LogLevel.Warning,
+                   It.IsAny<EventId>(),
+                   It.Is<It.IsAnyType>((v, t) => v.ToString().Contains("Business rule violation.")),
+                   It.IsAny<BusinessRuleException>(),
+                   It.IsAny<Func<It.IsAnyType, Exception, string>>()),
+               Times.Once);
+            activity.Stop();
+        }
+    }
+}

--- a/GateKeeper.Server/Controllers/AuthenticationController.cs
+++ b/GateKeeper.Server/Controllers/AuthenticationController.cs
@@ -91,12 +91,8 @@ namespace GateKeeper.Server.Controllers
             {
                 response.FailureReason = $"{InternalError}: {ex.Message}";
                 response.IsSuccessful = false;
-                _logger.LogError(ex, "{FunctionName}('{Email}','{UserName}') - Error: {ErrorMessage}",
-                    FunctionName(),
-                    registerRequest.Email.SanitizeForLogging(),
-                    registerRequest.Username.SanitizeForLogging(),
-                    ex.Message);
-                return StatusCode(500, new { error = InternalError });
+                // Removed generic catch block, error will be handled by GlobalExceptionHandlerMiddleware
+                throw; // Re-throw the exception to be caught by the global handler
             }
             finally
             {
@@ -137,9 +133,8 @@ namespace GateKeeper.Server.Controllers
                 response.FailureReason = $"{InternalError}: {ex.Message}";
                 if (response.User != null)
                     await response.User.ClearPHIAsync();
-                _logger.LogError(ex, "{FunctionName}() - Error: {ErrorMessage}",
-                    FunctionName(), ex.Message);
-                return StatusCode(500, new { error = InternalError });
+                // Removed generic catch block, error will be handled by GlobalExceptionHandlerMiddleware
+                throw; // Re-throw the exception to be caught by the global handler
             }
             finally
             {
@@ -199,9 +194,8 @@ namespace GateKeeper.Server.Controllers
             {
                 response.IsSuccessful = false;
                 response.FailureReason = $"{InternalError}: {ex.Message}";
-                _logger.LogError(ex, "{FunctionName}('{Identifier}') - Error: {ErrorMessage}",
-                    FunctionName(), loginRequest.Identifier.SanitizeForLogging(), ex.Message);
-                return StatusCode(500, new { error = InternalError });
+                // Removed generic catch block, error will be handled by GlobalExceptionHandlerMiddleware
+                throw; // Re-throw the exception to be caught by the global handler
             }
             finally
             {
@@ -250,9 +244,8 @@ namespace GateKeeper.Server.Controllers
             {
                 response.IsSuccessful = false;
                 response.FailureReason = $"{InternalError}: {ex.Message}";
-                _logger.LogError(ex, "{FunctionName}() - Error: {ErrorMessage}",
-                    FunctionName(), ex.Message);
-                return StatusCode(500, new { error = InternalError });
+                // Removed generic catch block, error will be handled by GlobalExceptionHandlerMiddleware
+                throw; // Re-throw the exception to be caught by the global handler
             }
             finally
             {
@@ -292,9 +285,8 @@ namespace GateKeeper.Server.Controllers
             {
                 revokedCount = 0;
                 failureReason = $"{InternalError}: {ex.Message}";
-                _logger.LogError(ex, "{FunctionName}('{UserId}') - Error: {ErrorMessage}",
-                    FunctionName(), userId, ex.Message);
-                return StatusCode(500, new { error = InternalError });
+                // Removed generic catch block, error will be handled by GlobalExceptionHandlerMiddleware
+                throw; // Re-throw the exception to be caught by the global handler
             }
             finally
             {
@@ -344,12 +336,11 @@ namespace GateKeeper.Server.Controllers
                 });
 
             }
-            catch (Exception ex)
+            catch (Exception ex) // This outer catch is being removed
             {
                 failureReason = $"{InternalError}: {ex.Message}";
-                _logger.LogError(ex, "{FunctionName}('{UserId}') - Error: {ErrorMessage}",
-                    FunctionName(), userId, ex.Message);
-                return StatusCode(500, new { error = InternalError });
+                // Removed generic catch block, error will be handled by GlobalExceptionHandlerMiddleware
+                throw; // Re-throw the exception to be caught by the global handler
             }
             finally
             {
@@ -387,11 +378,8 @@ namespace GateKeeper.Server.Controllers
                 response.FailureReason = $"{InternalError}: {ex.Message}";
                 response.IsVerified = false;
                 response.User?.ClearPHIAsync();
-
-                _logger.LogError(ex, "{FunctionName}() - Error: {ErrorMessage}",
-                    FunctionName(), ex.Message);
-                return StatusCode(500, new { error = InternalError });
-
+                // Removed generic catch block, error will be handled by GlobalExceptionHandlerMiddleware
+                throw; // Re-throw the exception to be caught by the global handler
             }
             finally
             {
@@ -423,9 +411,12 @@ namespace GateKeeper.Server.Controllers
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "{FunctionName}() - Error: {ErrorMessage}",
-                    FunctionName(), ex.Message);
-                return StatusCode(500, new { error = InternalError });
+                // Removed generic catch block, error will be handled by GlobalExceptionHandlerMiddleware
+                throw; // Re-throw the exception to be caught by the global handler
+                // Removed generic catch block, error will be handled by GlobalExceptionHandlerMiddleware
+                throw; // Re-throw the exception to be caught by the global handler
+                // Removed generic catch block, error will be handled by GlobalExceptionHandlerMiddleware
+                throw; // Re-throw the exception to be caught by the global handler
             }
         }
 
@@ -500,9 +491,8 @@ namespace GateKeeper.Server.Controllers
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "{FunctionName}('{SessionId}') - Error: {ErrorMessage}", 
-                    FunctionName(), logoutDeviceRequest.SessionId.SanitizeForLogging(), ex.Message);
-                return StatusCode(500, new { error = InternalError });
+                // Removed generic catch block, error will be handled by GlobalExceptionHandlerMiddleware
+                throw; // Re-throw the exception to be caught by the global handler
             }
         }
 

--- a/GateKeeper.Server/Controllers/EmailController.cs
+++ b/GateKeeper.Server/Controllers/EmailController.cs
@@ -30,8 +30,8 @@ namespace GateKeeper.Server.Controllers
             }
             catch (Exception ex)
             {
-                _logger.LogError("An error occurred: {ErrorMessage}", ex.Message);
-                return StatusCode(500, "An error occurred");
+                // Removed generic catch block, error will be handled by GlobalExceptionHandlerMiddleware
+                throw; // Re-throw the exception to be caught by the global handler
             }
         }
     }

--- a/GateKeeper.Server/Controllers/GroupController.cs
+++ b/GateKeeper.Server/Controllers/GroupController.cs
@@ -45,8 +45,8 @@ namespace GateKeeper.Server.Controllers
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "There was an error: {ErrorMessage}", ex.Message);
-                return StatusCode(500, new { error = "There was an error" });
+                // Removed generic catch block, error will be handled by GlobalExceptionHandlerMiddleware
+                throw; // Re-throw the exception to be caught by the global handler
             }
         }
     }

--- a/GateKeeper.Server/Controllers/InviteController.cs
+++ b/GateKeeper.Server/Controllers/InviteController.cs
@@ -73,7 +73,8 @@ namespace GateKeeper.Server.Controllers
                     userIp,
                     ex.Message
                 );
-                return StatusCode(500, new { error = "An error occurred while sending the invite." });
+                // Removed generic catch block, error will be handled by GlobalExceptionHandlerMiddleware
+                throw; // Re-throw the exception to be caught by the global handler
             }
             finally
             {
@@ -116,7 +117,8 @@ namespace GateKeeper.Server.Controllers
                     userIp,
                     ex.Message
                 );
-                return StatusCode(500, new { error = "An error occurred while retrieving invites." });
+                // Removed generic catch block, error will be handled by GlobalExceptionHandlerMiddleware
+                throw; // Re-throw the exception to be caught by the global handler
             }
             finally
             {
@@ -146,7 +148,8 @@ namespace GateKeeper.Server.Controllers
                     FunctionName(),
                     ex.Message
                 );
-                return StatusCode(500, new { error = "Error retrieving invites required." });
+                // Removed generic catch block, error will be handled by GlobalExceptionHandlerMiddleware
+                throw; // Re-throw the exception to be caught by the global handler
             }
             finally
             {

--- a/GateKeeper.Server/Controllers/LogsController.cs
+++ b/GateKeeper.Server/Controllers/LogsController.cs
@@ -171,7 +171,9 @@ namespace GateKeeper.Server.Controllers
             }
             catch (Exception ex)
             {
-                return HandleInternalError(ex, "An error occurred while reading chained logs.");
+                // Removed generic catch block and HandleInternalError call, 
+                // error will be handled by GlobalExceptionHandlerMiddleware
+                throw; // Re-throw the exception to be caught by the global handler
             }
         }
 
@@ -257,11 +259,6 @@ namespace GateKeeper.Server.Controllers
             return result;
         }
 
-        private IActionResult HandleInternalError(Exception ex, string errorMessageTemplate)
-        {
-            var errorMessage = $"{errorMessageTemplate} => {ex.Message}";
-            _logger.LogError(ex, errorMessage);
-            return StatusCode(500, new { error = errorMessage });
-        }
+        // Removed HandleInternalError method as its functionality is now covered by GlobalExceptionHandlerMiddleware
     }
 }

--- a/GateKeeper.Server/Controllers/NotificationController.cs
+++ b/GateKeeper.Server/Controllers/NotificationController.cs
@@ -48,8 +48,8 @@ namespace GateKeeper.Server.Controllers
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error occurred while fetching all notifications: {ErrorMessage}", ex.Message);
-                return StatusCode(500, new { error = "Error occurred while fetching all notifications" });
+                // Removed generic catch block, error will be handled by GlobalExceptionHandlerMiddleware
+                throw; // Re-throw the exception to be caught by the global handler
             }
         }
 
@@ -69,8 +69,8 @@ namespace GateKeeper.Server.Controllers
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error retrieving notifications for user {RecipientId}: {ErrorMessage}", recipientId, ex.Message);
-                return StatusCode(500, new { error = "Error retrieving notifications" });
+                // Removed generic catch block, error will be handled by GlobalExceptionHandlerMiddleware
+                throw; // Re-throw the exception to be caught by the global handler
             }
         }
 
@@ -91,8 +91,8 @@ namespace GateKeeper.Server.Controllers
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error retrieving not-sent notifications: {ErrorMessage}", ex.Message);
-                return StatusCode(500, new { error = "Error retrieving not-sent notifications" });
+                // Removed generic catch block, error will be handled by GlobalExceptionHandlerMiddleware
+                throw; // Re-throw the exception to be caught by the global handler
             }
         }
 
@@ -120,8 +120,8 @@ namespace GateKeeper.Server.Controllers
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error creating new notification: {ErrorMessage}", ex.Message);
-                return StatusCode(500, new { error = "Error creating new notification" });
+                // Removed generic catch block, error will be handled by GlobalExceptionHandlerMiddleware
+                throw; // Re-throw the exception to be caught by the global handler
             }
         }
     }

--- a/GateKeeper.Server/Controllers/NotificationTemplateController.cs
+++ b/GateKeeper.Server/Controllers/NotificationTemplateController.cs
@@ -48,8 +48,8 @@ namespace GateKeeper.Server.Controllers
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error occurred while fetching all notification templates: {ErrorMessage}", ex.Message);
-                return StatusCode(500, new { error = "Error occurred while fetching all notification templates" });
+                // Removed generic catch block, error will be handled by GlobalExceptionHandlerMiddleware
+                throw; // Re-throw the exception to be caught by the global handler
             }
         }
 
@@ -73,8 +73,8 @@ namespace GateKeeper.Server.Controllers
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error retrieving notification template with ID {Id}: {ErrorMessage}", id, ex.Message);
-                return StatusCode(500, new { error = "Error retrieving notification template" });
+                // Removed generic catch block, error will be handled by GlobalExceptionHandlerMiddleware
+                throw; // Re-throw the exception to be caught by the global handler
             }
         }
 
@@ -108,8 +108,8 @@ namespace GateKeeper.Server.Controllers
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error creating new notification template: {ErrorMessage}", ex.Message);
-                return StatusCode(500, new { error = "Error creating new notification template" });
+                // Removed generic catch block, error will be handled by GlobalExceptionHandlerMiddleware
+                throw; // Re-throw the exception to be caught by the global handler
             }
         }
 
@@ -139,8 +139,8 @@ namespace GateKeeper.Server.Controllers
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error updating notification template with ID {Id}: {ErrorMessage}", id, ex.Message);
-                return StatusCode(500, new { error = "Error updating notification template" });
+                // Removed generic catch block, error will be handled by GlobalExceptionHandlerMiddleware
+                throw; // Re-throw the exception to be caught by the global handler
             }
         }
 
@@ -160,8 +160,8 @@ namespace GateKeeper.Server.Controllers
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error deleting notification template with ID {Id}: {ErrorMessage}", id, ex.Message);
-                return StatusCode(500, new { error = "Error deleting notification template" });
+                // Removed generic catch block, error will be handled by GlobalExceptionHandlerMiddleware
+                throw; // Re-throw the exception to be caught by the global handler
             }
         }
     }

--- a/GateKeeper.Server/Controllers/ResourcesController.cs
+++ b/GateKeeper.Server/Controllers/ResourcesController.cs
@@ -38,9 +38,8 @@ namespace GateKeeper.Server.Controllers
             }
             catch (Exception ex)
             {
-                var errorMessage = string.Format("An unexpected error occurred while retrieving entries: {0}", ex.Message);
-                _logger.LogError(ex, errorMessage);
-                return StatusCode(500, new { error = errorMessage });
+                // Removed generic catch block, error will be handled by GlobalExceptionHandlerMiddleware
+                throw; // Re-throw the exception to be caught by the global handler
             }
         }
 
@@ -66,9 +65,8 @@ namespace GateKeeper.Server.Controllers
             }
             catch (Exception ex)
             {
-                var errorMessage = string.Format("An unexpected error occurred while adding a new entry: {0}", ex.Message);
-                _logger.LogError(ex, errorMessage);
-                return StatusCode(500, new { error = errorMessage });
+                // Removed generic catch block, error will be handled by GlobalExceptionHandlerMiddleware
+                throw; // Re-throw the exception to be caught by the global handler
             }
         }
 
@@ -107,9 +105,8 @@ namespace GateKeeper.Server.Controllers
             }
             catch (Exception ex)
             {
-                var errorMessage = string.Format("An unexpected error occurred while updating the entry: {0}", ex.Message);
-                _logger.LogError(ex, errorMessage);
-                return StatusCode(500, new { error = errorMessage });
+                // Removed generic catch block, error will be handled by GlobalExceptionHandlerMiddleware
+                throw; // Re-throw the exception to be caught by the global handler
             }
         }
     }

--- a/GateKeeper.Server/Controllers/RoleController .cs
+++ b/GateKeeper.Server/Controllers/RoleController .cs
@@ -43,9 +43,8 @@ namespace GateKeeper.Server.Controllers
             }
             catch (Exception ex)
             {
-                // If you have resource strings, you can use them here. Otherwise, a fixed message is fine.
-                _logger.LogError(ex, "Error occurred while fetching all roles: {ErrorMessage}", ex.Message);
-                return StatusCode(500, new { error = "Error occurred while fetching all roles" });
+                // Removed generic catch block, error will be handled by GlobalExceptionHandlerMiddleware
+                throw; // Re-throw the exception to be caught by the global handler
             }
         }
 
@@ -69,8 +68,8 @@ namespace GateKeeper.Server.Controllers
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error retrieving role with Id {Id}: {ErrorMessage}", id, ex.Message);
-                return StatusCode(500, new { error = "Error retrieving role" });
+                // Removed generic catch block, error will be handled by GlobalExceptionHandlerMiddleware
+                throw; // Re-throw the exception to be caught by the global handler
             }
         }
 
@@ -94,8 +93,8 @@ namespace GateKeeper.Server.Controllers
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error retrieving role with name '{RoleName}': {ErrorMessage}", roleName.SanitizeForLogging(), ex.Message);
-                return StatusCode(500, new { error = "Error retrieving role" });
+                // Removed generic catch block, error will be handled by GlobalExceptionHandlerMiddleware
+                throw; // Re-throw the exception to be caught by the global handler
             }
         }
 
@@ -116,8 +115,8 @@ namespace GateKeeper.Server.Controllers
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error creating new role: {ErrorMessage}", ex.Message);
-                return StatusCode(500, new { error = "Error creating new role" });
+                // Removed generic catch block, error will be handled by GlobalExceptionHandlerMiddleware
+                throw; // Re-throw the exception to be caught by the global handler
             }
         }
 
@@ -142,8 +141,8 @@ namespace GateKeeper.Server.Controllers
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error updating role with Id {Id}: {ErrorMessage}", id, ex.Message);
-                return StatusCode(500, new { error = "Error updating role" });
+                // Removed generic catch block, error will be handled by GlobalExceptionHandlerMiddleware
+                throw; // Re-throw the exception to be caught by the global handler
             }
         }
     }

--- a/GateKeeper.Server/Controllers/SessionController.cs
+++ b/GateKeeper.Server/Controllers/SessionController.cs
@@ -46,9 +46,10 @@ namespace GateKeeper.Server.Controllers
             }
             catch (Exception ex)
             {
-                var errorMessage = "An error occurred while retrieving active sessions.";
-                _logger.LogError(ex, "Error retrieving active sessions for UserId: {UserId}, IP: {IpAddress}", userId, userIp);
-                return StatusCode(500, new { error = errorMessage });
+                // Removed generic catch block, error will be handled by GlobalExceptionHandlerMiddleware
+                throw; // Re-throw the exception to be caught by the global handler
+                // Removed generic catch block, error will be handled by GlobalExceptionHandlerMiddleware
+                throw; // Re-throw the exception to be caught by the global handler
             }
             finally
             {
@@ -100,9 +101,8 @@ namespace GateKeeper.Server.Controllers
             }
             catch (Exception ex)
             {
-                var errorMessage = "An error occurred while retrieving recent activity sessions.";
-                _logger.LogError(ex, "Error retrieving recent sessions for AdminUserId: {AdminUserId}, IP: {IpAddress}", adminUserId, userIp);
-                return StatusCode(500, new { error = errorMessage });
+                // Removed generic catch block, error will be handled by GlobalExceptionHandlerMiddleware
+                throw; // Re-throw the exception to be caught by the global handler
             }
             finally
             {

--- a/GateKeeper.Server/Controllers/SettingsController.cs
+++ b/GateKeeper.Server/Controllers/SettingsController.cs
@@ -58,8 +58,8 @@ namespace GateKeeper.Server.Controllers
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error occurred while fetching all settings: {ErrorMessage}", ex.Message);
-                return StatusCode(500, new { error = "Error occurred while fetching all settings" });
+                // Removed generic catch block, error will be handled by GlobalExceptionHandlerMiddleware
+                throw; // Re-throw the exception to be caught by the global handler
             }
         }
 
@@ -83,8 +83,8 @@ namespace GateKeeper.Server.Controllers
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error retrieving setting with Id {Id}: {ErrorMessage}", id, ex.Message);
-                return StatusCode(500, new { error = "Error retrieving setting" });
+                // Removed generic catch block, error will be handled by GlobalExceptionHandlerMiddleware
+                throw; // Re-throw the exception to be caught by the global handler
             }
         }
 
@@ -113,8 +113,10 @@ namespace GateKeeper.Server.Controllers
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error creating new setting: {ErrorMessage}", ex.Message);
-                return StatusCode(500, new { error = "Error creating new setting" });
+                // Removed generic catch block, error will be handled by GlobalExceptionHandlerMiddleware
+                throw; // Re-throw the exception to be caught by the global handler
+                // Removed generic catch block, error will be handled by GlobalExceptionHandlerMiddleware
+                throw; // Re-throw the exception to be caught by the global handler
             }
         }
 
@@ -182,8 +184,8 @@ namespace GateKeeper.Server.Controllers
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error updating setting with Id {Id}: {ErrorMessage}", id, ex.Message);
-                return StatusCode(500, new { error = "Error updating setting" });
+                // Removed generic catch block, error will be handled by GlobalExceptionHandlerMiddleware
+                throw; // Re-throw the exception to be caught by the global handler
             }
         }
 
@@ -208,8 +210,8 @@ namespace GateKeeper.Server.Controllers
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error deleting setting with Id {Id}: {ErrorMessage}", id, ex.Message);
-                return StatusCode(500, new { error = "Error deleting setting" });
+                // Removed generic catch block, error will be handled by GlobalExceptionHandlerMiddleware
+                throw; // Re-throw the exception to be caught by the global handler
             }
         }
 
@@ -230,8 +232,8 @@ namespace GateKeeper.Server.Controllers
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error retrieving settings in category '{Category}': {ErrorMessage}", category.SanitizeForLogging(), ex.Message);
-                return StatusCode(500, new { error = "Error retrieving settings in category" });
+                // Removed generic catch block, error will be handled by GlobalExceptionHandlerMiddleware
+                throw; // Re-throw the exception to be caught by the global handler
             }
         }
 
@@ -254,8 +256,8 @@ namespace GateKeeper.Server.Controllers
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error searching settings with Name='{Name}' and Category='{Category}': {ErrorMessage}", name.SanitizeForLogging(), category.SanitizeForLogging(), ex.Message);
-                return StatusCode(500, new { error = "Error searching settings" });
+                // Removed generic catch block, error will be handled by GlobalExceptionHandlerMiddleware
+                throw; // Re-throw the exception to be caught by the global handler
             }
         }
 
@@ -290,8 +292,8 @@ namespace GateKeeper.Server.Controllers
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error in AddOrUpdate operation for setting '{Name}': {ErrorMessage}", setting.Name.SanitizeForLogging(), ex.Message);
-                return StatusCode(500, new { error = "Error in AddOrUpdate operation for setting" });
+                // Removed generic catch block, error will be handled by GlobalExceptionHandlerMiddleware
+                throw; // Re-throw the exception to be caught by the global handler
             }
         }
 
@@ -302,12 +304,7 @@ namespace GateKeeper.Server.Controllers
             return int.Parse(User.FindFirst(ClaimTypes.NameIdentifier)?.Value ?? "0");
         }
 
-        private IActionResult HandleInternalError(Exception ex, string errorMessageTemplate)
-        {
-            var errorMessage = string.Format(errorMessageTemplate, ex.Message);
-            _logger.LogError(ex, errorMessage);
-            return StatusCode(500, new { error = errorMessage });
-        }
+        // Removed HandleInternalError method as its functionality is now covered by GlobalExceptionHandlerMiddleware
         #endregion
     }
 }

--- a/GateKeeper.Server/Controllers/UserController.cs
+++ b/GateKeeper.Server/Controllers/UserController.cs
@@ -72,8 +72,8 @@ namespace GateKeeper.Server.Controllers
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error updating user: {UserId}, IP: {IpAddress}, Device: {UserAgent}", userId, userIp, userAgent);
-                return StatusCode(500, new { error = "An error occurred while updating the user." });
+                // Removed generic catch block, error will be handled by GlobalExceptionHandlerMiddleware
+                throw; // Re-throw the exception to be caught by the global handler
             }
             finally
             {
@@ -103,8 +103,8 @@ namespace GateKeeper.Server.Controllers
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error retrieving profile: {UserId}, IP: {IpAddress}", userId, userIp);
-                return StatusCode(500, new { error = "An error occurred while retrieving the user profile." });
+                // Removed generic catch block, error will be handled by GlobalExceptionHandlerMiddleware
+                throw; // Re-throw the exception to be caught by the global handler
             }
             finally
             {
@@ -130,8 +130,8 @@ namespace GateKeeper.Server.Controllers
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error retrieving users: AdminUserId: {AdminUserId}, IP: {IpAddress}", adminUserId, userIp);
-                return StatusCode(500, new { error = "An error occurred while retrieving users." });
+                // Removed generic catch block, error will be handled by GlobalExceptionHandlerMiddleware
+                throw; // Re-throw the exception to be caught by the global handler
             }
             finally
             {
@@ -165,8 +165,8 @@ namespace GateKeeper.Server.Controllers
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error retrieving user: RequestedUserId: {UserId}, AdminUserId: {AdminUserId}, IP: {IpAddress}", userId, adminUserId, userIp);
-                return StatusCode(500, new { error = "An error occurred while retrieving the user." });
+                // Removed generic catch block, error will be handled by GlobalExceptionHandlerMiddleware
+                throw; // Re-throw the exception to be caught by the global handler
             }
             finally
             {
@@ -200,8 +200,8 @@ namespace GateKeeper.Server.Controllers
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error retrieving user for edit: RequestedUserId: {UserId}, AdminUserId: {AdminUserId}, IP: {IpAddress}", userId, adminUserId, userIp);
-                return StatusCode(500, new { error = "An error occurred while retrieving the user for edit." });
+                // Removed generic catch block, error will be handled by GlobalExceptionHandlerMiddleware
+                throw; // Re-throw the exception to be caught by the global handler
             }
             finally
             {
@@ -285,8 +285,8 @@ namespace GateKeeper.Server.Controllers
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error updating user with image: {UserId}, IP: {IpAddress}, Device: {UserAgent}", userId, userIp, userAgent);
-                return StatusCode(500, new { error = "An error occurred while updating the user." });
+                // Removed generic catch block, error will be handled by GlobalExceptionHandlerMiddleware
+                throw; // Re-throw the exception to be caught by the global handler
             }
             finally
             {
@@ -318,8 +318,8 @@ namespace GateKeeper.Server.Controllers
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error retrieving profile picture: RequestedUserId: {UserId}, IP: {IpAddress}", userId, userIp);
-                return StatusCode(500, new { error = "An error occurred while retrieving the profile picture." });
+                // Removed generic catch block, error will be handled by GlobalExceptionHandlerMiddleware
+                throw; // Re-throw the exception to be caught by the global handler
             }
             finally
             {

--- a/GateKeeper.Server/Controllers/VerificationController.cs
+++ b/GateKeeper.Server/Controllers/VerificationController.cs
@@ -58,9 +58,8 @@ namespace GateKeeper.Server.Controllers
             }
             catch (Exception ex)
             {
-                response.FailureReason = "Internal error:" + ex.Message;
-                _logger.LogError(ex, "An error occurred during validation token validation.");
-                return StatusCode(500, new { error = "An error occurred during validation token validation." });
+                // Removed generic catch block, error will be handled by GlobalExceptionHandlerMiddleware
+                throw; // Re-throw the exception to be caught by the global handler
             }
             finally
             {
@@ -100,8 +99,8 @@ namespace GateKeeper.Server.Controllers
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "An error occurred during user verification.");
-                return StatusCode(500, new { error = "An error occurred while verifying the user." });
+                // Removed generic catch block, error will be handled by GlobalExceptionHandlerMiddleware
+                throw; // Re-throw the exception to be caught by the global handler
             }
         }
     }

--- a/GateKeeper.Server/Exceptions/BusinessRuleException.cs
+++ b/GateKeeper.Server/Exceptions/BusinessRuleException.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace GateKeeper.Server.Exceptions
+{
+    public class BusinessRuleException : Exception
+    {
+        public BusinessRuleException(string message) : base(message) { }
+        public BusinessRuleException(string message, Exception innerException) : base(message, innerException) { }
+    }
+}

--- a/GateKeeper.Server/Exceptions/ResourceNotFoundException.cs
+++ b/GateKeeper.Server/Exceptions/ResourceNotFoundException.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace GateKeeper.Server.Exceptions
+{
+    public class ResourceNotFoundException : Exception
+    {
+        public ResourceNotFoundException(string message) : base(message) { }
+        public ResourceNotFoundException(string message, Exception innerException) : base(message, innerException) { }
+    }
+}

--- a/GateKeeper.Server/Exceptions/ValidationException.cs
+++ b/GateKeeper.Server/Exceptions/ValidationException.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace GateKeeper.Server.Exceptions
+{
+    public class ValidationException : Exception
+    {
+        public ValidationException(string message) : base(message) { }
+        public ValidationException(string message, Exception innerException) : base(message, innerException) { }
+    }
+}

--- a/GateKeeper.Server/Middleware/GlobalExceptionHandlerMiddleware.cs
+++ b/GateKeeper.Server/Middleware/GlobalExceptionHandlerMiddleware.cs
@@ -1,0 +1,90 @@
+using GateKeeper.Server.Exceptions; // Added for custom exceptions
+using GateKeeper.Server.Models.Common; // Added for ErrorResponse
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Hosting; // Added for IHostEnvironment
+using Microsoft.Extensions.Logging;
+using System;
+using System.Diagnostics; // Added for Activity
+using System.Text.Json; // Added for JsonSerializer
+using System.Threading.Tasks;
+
+namespace GateKeeper.Server.Middleware
+{
+    public class GlobalExceptionHandlerMiddleware
+    {
+        private readonly RequestDelegate _next;
+        private readonly ILogger<GlobalExceptionHandlerMiddleware> _logger;
+        private readonly IHostEnvironment _env; // Added for environment check
+
+        public GlobalExceptionHandlerMiddleware(RequestDelegate next, ILogger<GlobalExceptionHandlerMiddleware> logger, IHostEnvironment env) // Added IHostEnvironment
+        {
+            _next = next;
+            _logger = logger;
+            _env = env; // Store injected IHostEnvironment
+        }
+
+        public async Task InvokeAsync(HttpContext context)
+        {
+            try
+            {
+                await _next(context);
+            }
+            catch (ValidationException ex) // Specific exception
+            {
+                _logger.LogWarning(ex, "Validation error. TraceId: {TraceId}", context.TraceIdentifier);
+                context.Response.ContentType = "application/json";
+                context.Response.StatusCode = StatusCodes.Status400BadRequest;
+                var response = new ErrorResponse
+                {
+                    StatusCode = context.Response.StatusCode,
+                    Message = ex.Message, // Message from the exception
+                    Details = _env.IsDevelopment() ? ex.ToString() : null,
+                    TraceId = Activity.Current?.Id ?? context.TraceIdentifier
+                };
+                await context.Response.WriteAsync(JsonSerializer.Serialize(response));
+            }
+            catch (ResourceNotFoundException ex) // Specific exception
+            {
+                _logger.LogWarning(ex, "Resource not found. TraceId: {TraceId}", context.TraceIdentifier);
+                context.Response.ContentType = "application/json";
+                context.Response.StatusCode = StatusCodes.Status404NotFound;
+                var response = new ErrorResponse
+                {
+                    StatusCode = context.Response.StatusCode,
+                    Message = ex.Message, // Message from the exception
+                    Details = _env.IsDevelopment() ? ex.ToString() : null,
+                    TraceId = Activity.Current?.Id ?? context.TraceIdentifier
+                };
+                await context.Response.WriteAsync(JsonSerializer.Serialize(response));
+            }
+            catch (BusinessRuleException ex) // Specific exception
+            {
+                _logger.LogWarning(ex, "Business rule violation. TraceId: {TraceId}", context.TraceIdentifier);
+                context.Response.ContentType = "application/json";
+                context.Response.StatusCode = StatusCodes.Status400BadRequest; // Or StatusCodes.Status409Conflict if more appropriate
+                var response = new ErrorResponse
+                {
+                    StatusCode = context.Response.StatusCode,
+                    Message = ex.Message, // Message from the exception
+                    Details = _env.IsDevelopment() ? ex.ToString() : null,
+                    TraceId = Activity.Current?.Id ?? context.TraceIdentifier
+                };
+                await context.Response.WriteAsync(JsonSerializer.Serialize(response));
+            }
+            catch (Exception ex) // Generic fallback
+            {
+                _logger.LogError(ex, "An unhandled exception has occurred. TraceId: {TraceId}", context.TraceIdentifier);
+                context.Response.ContentType = "application/json";
+                context.Response.StatusCode = StatusCodes.Status500InternalServerError;
+                var response = new ErrorResponse
+                {
+                    StatusCode = context.Response.StatusCode,
+                    Message = "An unexpected internal server error occurred. Please try again later.",
+                    Details = _env.IsDevelopment() ? ex.ToString() : null,
+                    TraceId = Activity.Current?.Id ?? context.TraceIdentifier
+                };
+                await context.Response.WriteAsync(JsonSerializer.Serialize(response));
+            }
+        }
+    }
+}

--- a/GateKeeper.Server/Models/Common/ErrorResponse.cs
+++ b/GateKeeper.Server/Models/Common/ErrorResponse.cs
@@ -1,0 +1,10 @@
+namespace GateKeeper.Server.Models.Common
+{
+    public class ErrorResponse
+    {
+        public int StatusCode { get; set; }
+        public string Message { get; set; }
+        public string? Details { get; set; }
+        public string? TraceId { get; set; }
+    }
+}

--- a/GateKeeper.Server/Program.cs
+++ b/GateKeeper.Server/Program.cs
@@ -275,6 +275,7 @@ builder.Services.AddAuthorization();
 var app = builder.Build();
 
 app.UseMiddleware<LogEnrichmentMiddleware>();
+app.UseMiddleware<GlobalExceptionHandlerMiddleware>(); // Added Global Exception Handler
 
 app.UseDefaultFiles();
 app.UseStaticFiles();

--- a/README.md
+++ b/README.md
@@ -156,6 +156,52 @@ Both frontend and backend include unit tests.
   * **Backend Tests:** Navigate to `GateKeeper.Server` (or the test project directory) and run `dotnet test`.
     Refer to [GetStarted.md](https://www.google.com/search?q=GetStarted.md%23testing) for more details on running tests.
 
+## Error Handling
+
+The GateKeeper API employs a centralized error handling middleware to provide consistent error responses. When an error occurs, the API will return a JSON response in a standard format.
+
+### Standard Error Response Format
+
+The `ErrorResponse` model includes the following properties:
+
+*   `StatusCode` (int): The HTTP status code for the error (e.g., 400, 404, 500).
+*   `Message` (string): A human-readable message summarizing the error. For specific errors like validation or business rule violations, this message will provide more context.
+*   `Details` (string, optional): Contains more detailed error information, such as a stack trace. This field is ONLY populated in development environments for debugging purposes and will be `null` in production environments to avoid exposing sensitive information.
+*   `TraceId` (string): A unique identifier for the request. This ID is logged by the server and can be used to correlate server-side logs with the specific error encountered by the client. Please include this `TraceId` when reporting issues.
+
+**Example JSON Error Response:**
+
+```json
+{
+  "StatusCode": 500,
+  "Message": "An unexpected internal server error occurred. Please try again later.",
+  "Details": null, // Or a detailed error string (e.g., stack trace) in development
+  "TraceId": "0HM123456789ABCDEF"
+}
+```
+
+### Common HTTP Status Codes
+
+The API uses standard HTTP status codes to indicate the success or failure of an API request. Here are some common ones you might encounter:
+
+*   **`400 Bad Request`**: This can indicate several issues:
+    *   **Validation Errors**: Input data failed validation (e.g., missing required fields, invalid data format). The `Message` field will often detail which fields are problematic.
+    *   **Business Rule Violations**: The request violated a specific business rule (e.g., trying to create a duplicate entry where it's not allowed). The `Message` will describe the rule violation.
+*   **`401 Unauthorized`**: Authentication is required to access the resource, and the request either lacked authentication credentials or the provided credentials were invalid.
+*   **`403 Forbidden`**: The authenticated user does not have the necessary permissions to perform the requested action on the resource.
+*   **`404 Not Found`**: The requested resource (e.g., a specific user, role, or setting) could not be found on the server.
+*   **`500 Internal Server Error`**: An unexpected error occurred on the server that prevented it from fulfilling the request. The `Message` will typically be generic. Use the `TraceId` to help administrators locate the corresponding server logs for more details.
+
+### Custom Exceptions
+
+The centralized error handler is designed to catch specific custom exceptions and map them to appropriate HTTP status codes and user-friendly messages. These include:
+
+*   `ValidationException`: Typically results in a `400 Bad Request` with a message detailing the validation failure.
+*   `ResourceNotFoundException`: Results in a `404 Not Found` with a message indicating the resource was not found.
+*   `BusinessRuleException`: Typically results in a `400 Bad Request` (or sometimes `409 Conflict`) with a message explaining the business rule that was violated.
+
+This approach ensures that clients receive predictable and informative error responses, aiding in debugging and integration.
+
 ## Documentation & Project Structure
 
   * **[GetStarted.md](https://www.google.com/search?q=GetStarted.md):** Comprehensive guide for installation, detailed configuration, and setup.


### PR DESCRIPTION
This commit introduces a global error handling middleware to standardize error responses across the API.

Key changes include:
- Added `.NET 8` support and established a baseline.
- Defined a standard `ErrorResponse` model (`GateKeeper.Server/Models/Common/ErrorResponse.cs`) with `StatusCode`, `Message`, `Details` (for development), and `TraceId`.
- Created `GlobalExceptionHandlerMiddleware` (`GateKeeper.Server/Middleware/GlobalExceptionHandlerMiddleware.cs`) to catch unhandled exceptions and format them using `ErrorResponse`.
- The middleware logs exceptions and provides detailed error information in development environments while returning generic messages in production.
- Registered the middleware in `Program.cs`.
- Refactored controllers to remove redundant generic try-catch blocks, relying on the new middleware for unhandled exceptions. Specific error handling in controllers remains.
- Enhanced the middleware to handle specific custom exceptions:
    - `ValidationException` (400 Bad Request)
    - `ResourceNotFoundException` (404 Not Found)
    - `BusinessRuleException` (400 Bad Request)
- Added comprehensive MSTest unit tests for `GlobalExceptionHandlerMiddleware` to ensure its correctness under various scenarios (generic exceptions, custom exceptions, dev/prod environments).
- Updated `README.md` to document the new error handling strategy, standard error response format, common status codes, and custom exceptions.

This centralized approach improves consistency, reduces boilerplate code in controllers, and provides a clear contract for API error responses.