### PR TITLE
Refactor: Update database connection string source

### DIFF
--- a/GateKeeper.Server/Models/Configuration/DatabaseConfig.cs
+++ b/GateKeeper.Server/Models/Configuration/DatabaseConfig.cs
@@ -5,9 +5,9 @@ namespace GateKeeper.Server.Models.Configuration
 {
     public class DatabaseConfig
     {
-        public const string SectionName = "DatabaseConfig"; // Or "ConnectionStrings" if that's the section name in appsettings.json
+        public const string SectionName = "ConnectionStrings"; // Or "ConnectionStrings" if that's the section name in appsettings.json
 
         [Required]
-        public string ConnectionString { get; set; } 
+        public string GateKeeperConnection { get; set; }
     }
 }

--- a/GateKeeper.Server/Program.cs
+++ b/GateKeeper.Server/Program.cs
@@ -78,7 +78,7 @@ builder.Services.AddOptions<EmailSettingsConfig>()
     .ValidateOnStart();
 
 builder.Services.AddOptions<DatabaseConfig>()
-    .Bind(builder.Configuration.GetSection(DatabaseConfig.SectionName))
+    .Bind(builder.Configuration.GetSection("ConnectionStrings"))
     .ValidateDataAnnotations()
     .ValidateOnStart();
 

--- a/GateKeeper.Server/Services/DBHelper.cs
+++ b/GateKeeper.Server/Services/DBHelper.cs
@@ -15,7 +15,7 @@ public class DBHelper : IDbHelper
     {
         _dbConfig = dbConfigOptions.Value;
         // Basic validation, though Program.cs handles more comprehensive validation
-        if (string.IsNullOrWhiteSpace(_dbConfig.ConnectionString))
+        if (string.IsNullOrWhiteSpace(_dbConfig.GateKeeperConnection))
         {
             throw new InvalidOperationException("Database connection string is not configured.");
         }
@@ -24,7 +24,7 @@ public class DBHelper : IDbHelper
     public async Task<IMySqlConnectorWrapper> GetWrapperAsync()
     {
         // Using the ConnectionString directly from the injected and validated DatabaseConfig
-        return await new MySqlConnectorWrapper(_dbConfig.ConnectionString).OpenConnectionAsync();
+        return await new MySqlConnectorWrapper(_dbConfig.GateKeeperConnection).OpenConnectionAsync();
     }
 }
 

--- a/GateKeeper.Server/UserSecret.Example
+++ b/GateKeeper.Server/UserSecret.Example
@@ -13,11 +13,9 @@
     "TokenValidityInMinutes": 15,
     "RefreshTokenValidityInDays": 30
   },
-  "DatabaseConfig": {
-    "ConnectionString": ""
-  },
   "ConnectionStrings": {
-    "HangfireConnection": ""
+    "HangfireConnection": "",
+    "GateKeeperConnection": ""
   },
   "KeyManagement": {
     "MasterKey": ""


### PR DESCRIPTION
This commit changes the source of the main database connection string.

Previously, the application expected the connection string to be located at `DatabaseConfig:ConnectionString` in the configuration.

This has been changed to `ConnectionStrings:GateKeeperConnection`.

The following changes were made:
- Modified `DatabaseConfig.cs` to change `SectionName` to "ConnectionStrings" and rename the `ConnectionString` property to `GateKeeperConnection`.
- Updated `DBHelper.cs` to use the new `GateKeeperConnection` property.
- Updated `Program.cs` to bind `DatabaseConfig` to the "ConnectionStrings" section.
- Updated `UserSecret.Example` to reflect the new configuration structure.

Unit tests were reviewed, and no changes were necessary due to the existing mocking of `IDbHelper`.

You will need to update your local user secrets to match the new structure: `ConnectionStrings:GateKeeperConnection` instead of `DatabaseConfig:ConnectionString`.